### PR TITLE
Add library support for overseerr

### DIFF
--- a/custom_components/hassarr/services.py
+++ b/custom_components/hassarr/services.py
@@ -54,7 +54,6 @@ def handle_add_media(hass: HomeAssistant, call: ServiceCall, media_type: str, se
         _LOGGER.error("Title is missing in the service call data")
         return
    
-    
     _LOGGER.info(f"Title received: {title}")
 
     # Access stored configuration data

--- a/custom_components/hassarr/services.py
+++ b/custom_components/hassarr/services.py
@@ -53,7 +53,6 @@ def handle_add_media(hass: HomeAssistant, call: ServiceCall, media_type: str, se
     if not title:
         _LOGGER.error("Title is missing in the service call data")
         return
-   
     _LOGGER.info(f"Title received: {title}")
 
     # Access stored configuration data

--- a/custom_components/hassarr/services.py
+++ b/custom_components/hassarr/services.py
@@ -53,7 +53,8 @@ def handle_add_media(hass: HomeAssistant, call: ServiceCall, media_type: str, se
     if not title:
         _LOGGER.error("Title is missing in the service call data")
         return
-
+   
+    
     _LOGGER.info(f"Title received: {title}")
 
     # Access stored configuration data
@@ -122,11 +123,17 @@ def handle_add_overseerr_media(hass: HomeAssistant, call: ServiceCall, media_typ
     """
     _LOGGER.info(f"Received call data: {call.data}")
     title = call.data.get("title")
-
+    library = call.data.get("library")
+    
     if not title:
         _LOGGER.error("Title is missing in the service call data")
         return
-
+    if not library:
+        _LOGGER.info(f"Library received: {library}")
+        library = ""
+    else:
+        _LOGGER.info(f"Library received: {library}")
+        
     _LOGGER.info(f"Title received: {title}")
 
     # Access stored configuration data
@@ -173,7 +180,7 @@ def handle_add_overseerr_media(hass: HomeAssistant, call: ServiceCall, media_typ
             "is4k": False,
             "serverId": 0,
             "profileId": 0,
-            "rootFolder": "",
+            "rootFolder": "{library}",
             "languageProfileId": 0,
             "userId": config_data.get("overseerr_user_id"),
             "seasons": "all" if media_type == "tv" else []

--- a/custom_components/hassarr/services.yaml
+++ b/custom_components/hassarr/services.yaml
@@ -18,6 +18,9 @@ add_overseerr_movie:
     title:
       description: "Title of the movie"
       example: "Gladiator"
+    library:
+      description: "Path of the library"
+      example: "/media/movie"
 
 add_overseerr_tv_show:
   description: "Add a TV show to Overseerr"
@@ -25,3 +28,6 @@ add_overseerr_tv_show:
     title:
       description: "Title of the TV show"
       example: "Breaking Bad"
+    library:
+      description: "Path of the library"
+      example: "/media/tvshow"


### PR DESCRIPTION
I added variables but could not test it out... Can someone check it out ? :)

Use :

Add a variable with the exact library, we could set it in the automation after that.

Ex:

(Download | Download | Add | Send) the series {title} to the movie's library.

![image](https://github.com/user-attachments/assets/d4d270aa-dad4-43f2-8e2c-7579d7d20e57)

Thanks !