### PR TITLE
Overseer seasons requests/defaults . Cleaner config flow titles and descriptions. Config flow translations framework 

### DIFF
--- a/custom_components/hassarr/config_flow.py
+++ b/custom_components/hassarr/config_flow.py
@@ -100,14 +100,15 @@ class HassarrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Update the existing config entry
             data = dict(self._get_reconfigure_entry().data)
-            data.update(user_input)
+            # Map the descriptive field name back to the internal name
+            data["default_season"] = user_input["default_season_behavior"]
             self.hass.config_entries.async_update_entry(
                 self._get_reconfigure_entry(),
                 data=data
             )
             return self.async_update_reload_and_abort(
                 self._get_reconfigure_entry(),
-                data_updates=user_input,
+                data_updates={"default_season": user_input["default_season_behavior"]},
             )
 
         # Get existing data to pre-fill the form
@@ -117,7 +118,11 @@ class HassarrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure_overseerr_defaults",
             data_schema=vol.Schema({
-                vol.Required("default_season", default=default_season): vol.In(["All", "Season 1"]),
+                vol.Required(
+                    "default_season_behavior", 
+                    default=default_season,
+                    description="Default Season Behavior - Sets the default season behavior when no season(s) specified"
+                ): vol.In(["All", "Season 1"]),
             })
         )
 
@@ -269,7 +274,11 @@ class HassarrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="overseerr_defaults",
                 data_schema=vol.Schema({
-                    vol.Required("default_season", default="All"): vol.In(["All", "Season 1"]),
+                    vol.Required(
+                        "default_season_behavior", 
+                        default="All",
+                        description="Default Season Behavior - Sets the default season behavior when no season(s) specified"
+                    ): vol.In(["All", "Season 1"]),
                 })
             )
 
@@ -278,7 +287,7 @@ class HassarrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "overseerr_url": self.overseerr_url,
             "overseerr_api_key": self.overseerr_api_key,
             "overseerr_user_id": self.overseerr_user_id,
-            "default_season": user_input["default_season"],
+            "default_season": user_input["default_season_behavior"],  # Map back to internal name
             "integration_type": "Overseerr"
         }
         return self.async_create_entry(title="Hassarr", data=data)

--- a/custom_components/hassarr/services.py
+++ b/custom_components/hassarr/services.py
@@ -122,13 +122,25 @@ def handle_add_overseerr_media(hass: HomeAssistant, call: ServiceCall, media_typ
     """
     _LOGGER.info(f"Received call data: {call.data}")
     title = call.data.get("title")
+    
+    # Access stored configuration data
+    config_data = hass.data[DOMAIN]
+    
+    # Get seasons from call data, or use the configured default
+    default_season = config_data.get("default_season", "All")
+    if default_season == "Season 1":
+        default_seasons = [1]
+    else:  # "All"
+        default_seasons = "all"
+    
+    seasons = call.data.get("seasons", default_seasons)
 
     if not title:
         _LOGGER.error("Title is missing in the service call data")
         return
 
     _LOGGER.info(f"Title received: {title}")
-
+    
     # Access stored configuration data
     config_data = hass.data[DOMAIN]
 
@@ -176,7 +188,7 @@ def handle_add_overseerr_media(hass: HomeAssistant, call: ServiceCall, media_typ
             "rootFolder": "",
             "languageProfileId": 0,
             "userId": config_data.get("overseerr_user_id"),
-            "seasons": "all" if media_type == "tv" else []
+            "seasons": seasons if media_type == "tv" else []
         }
         if media_type == "tv":
             tvdb_id = media_data.get("tvdbId")

--- a/custom_components/hassarr/translations/en.json
+++ b/custom_components/hassarr/translations/en.json
@@ -42,7 +42,7 @@
         }
       },
       "overseerr_defaults": {
-        "title": "Overseerr Default Season Settings",
+        "title": "Overseerr Default Settings",
        "data": {
           "default_season_behavior": "Default Season Behavior - Configure how Overseerr handles requests of shows when no seasons are specified"
         }
@@ -70,7 +70,7 @@
         }
       },
       "reconfigure_overseerr_defaults": {
-        "title": "Overseerr Default Season Settings",
+        "title": "Overseerr Default Settings",
         "data": {
           "default_season_behavior": "Default Season Behavior - Configure how Overseerr handles requests of shows when no seasons are specified"
         }

--- a/custom_components/hassarr/translations/en.json
+++ b/custom_components/hassarr/translations/en.json
@@ -42,10 +42,9 @@
         }
       },
       "overseerr_defaults": {
-        "title": "Overseerr Default Settings",
-        "description": "Configure default behavior for Overseerr requests",
-        "data": {
-          "default_season_behavior": "Default Season Behavior"
+        "title": "Overseerr Default Season Settings",
+       "data": {
+          "default_season_behavior": "Default Season Behavior - Configure how Overseerr handles requests of shows when no seasons are specified"
         }
       },
       "reconfigure": {
@@ -71,10 +70,9 @@
         }
       },
       "reconfigure_overseerr_defaults": {
-        "title": "Update Overseerr Defaults",
-        "description": "Configure default behavior for Overseerr requests",
+        "title": "Overseerr Default Season Settings",
         "data": {
-          "default_season_behavior": "Default Season Behavior - Sets the default season selection when no seasons are specified"
+          "default_season_behavior": "Default Season Behavior - Configure how Overseerr handles requests of shows when no seasons are specified"
         }
       },
       "reconfigure_radarr_sonarr": {

--- a/custom_components/hassarr/translations/en.json
+++ b/custom_components/hassarr/translations/en.json
@@ -1,0 +1,117 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Choose Integration Type",
+        "description": "Select which media request system you want to integrate with",
+        "data": {
+          "integration_type": "Integration Type"
+        }
+      },
+      "radarr_sonarr": {
+        "title": "Radarr & Sonarr Connection",
+        "description": "Enter the connection details for your Radarr and Sonarr servers",
+        "data": {
+          "radarr_url": "Radarr URL",
+          "radarr_api_key": "Radarr API Key",
+          "sonarr_url": "Sonarr URL",
+          "sonarr_api_key": "Sonarr API Key"
+        }
+      },
+      "radarr_sonarr_quality_profiles": {
+        "title": "Quality Profiles",
+        "description": "Select your preferred quality profiles for movie and TV show requests",
+        "data": {
+          "radarr_quality_profile_id": "Radarr Quality Profile",
+          "sonarr_quality_profile_id": "Sonarr Quality Profile"
+        }
+      },
+      "overseerr": {
+        "title": "Overseerr Connection",
+        "description": "Enter the connection details for your Overseerr server",
+        "data": {
+          "overseerr_url": "Overseerr URL",
+          "overseerr_api_key": "Overseerr API Key"
+        }
+      },
+      "overseerr_user": {
+        "title": "Select Overseerr User",
+        "description": "Choose which Overseerr user will be used for requests",
+        "data": {
+          "overseerr_user_id": "Overseerr User"
+        }
+      },
+      "overseerr_defaults": {
+        "title": "Overseerr Default Settings",
+        "description": "Configure default behavior for Overseerr requests",
+        "data": {
+          "default_season_behavior": "Default Season Behavior"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Integration Type",
+        "description": "Select which media request system you want to integrate with",
+        "data": {
+          "integration_type": "Integration Type" 
+        }
+      },
+      "reconfigure_overseerr": {
+        "title": "Reconfigure Overseerr Connection",
+        "description": "Update your Overseerr connection details",
+        "data": {
+          "overseerr_url": "Overseerr URL",
+          "overseerr_api_key": "Overseerr API Key"
+        }
+      },
+      "reconfigure_overseerr_user": {
+        "title": "Update Overseerr User",
+        "description": "Select which Overseerr user will be used for requests",
+        "data": {
+          "overseerr_user_id": "Overseerr User"
+        }
+      },
+      "reconfigure_overseerr_defaults": {
+        "title": "Update Overseerr Defaults",
+        "description": "Configure default behavior for Overseerr requests",
+        "data": {
+          "default_season_behavior": "Default Season Behavior - Sets the default season selection when no seasons are specified"
+        }
+      },
+      "reconfigure_radarr_sonarr": {
+        "title": "Update Radarr & Sonarr Connection",
+        "description": "Update your Radarr and Sonarr server details",
+        "data": {
+          "radarr_url": "Radarr URL",
+          "radarr_api_key": "Radarr API Key",
+          "sonarr_url": "Sonarr URL",
+          "sonarr_api_key": "Sonarr API Key"
+        }
+      },
+      "reconfigure_radarr_sonarr_quality_profiles": {
+        "title": "Update Quality Profiles",
+        "description": "Select your preferred quality profiles for movie and TV show requests",
+        "data": {
+          "radarr_quality_profile_id": "Radarr Quality Profile",
+          "sonarr_quality_profile_id": "Sonarr Quality Profile"
+        }
+      }
+    },
+    "error": {
+      "missing_radarr_info": "Please provide both Radarr URL and API key",
+      "missing_sonarr_info": "Please provide both Sonarr URL and API key",
+      "missing_overseerr_info": "Please provide both Overseerr URL and API key",
+      "cannot_connect": "Failed to connect to the server"
+    },
+    "abort": {
+      "already_configured": "Integration is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure Hassarr Options",
+        "description": "Update configuration for your media request system"
+      }
+    }
+  }
+}

--- a/custom_components/hassarr/translations/es.json
+++ b/custom_components/hassarr/translations/es.json
@@ -42,7 +42,8 @@
         }
       },
       "overseerr_defaults": {
-        "title": "Configuración de Temporadas Predeterminada de Overseerr",
+        "title": "Configuración Predeterminada de Overseerr",
+        "description": "Configure los ajustes predeterminados para Overseerr",
         "data": {
           "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define cómo Overseerr maneja las solicitudes de series cuando no se especifican temporadas"
         }
@@ -70,7 +71,8 @@
         }
       },
       "reconfigure_overseerr_defaults": {
-        "title": "Configuración de Temporadas Predeterminada de Overseerr",
+        "title": "Configuración Predeterminada de Overseerr",
+        "description": "Configure los ajustes predeterminados para Overseerr",
         "data": {
           "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define cómo Overseerr maneja las solicitudes de series cuando no se especifican temporadas"
         }

--- a/custom_components/hassarr/translations/es.json
+++ b/custom_components/hassarr/translations/es.json
@@ -42,10 +42,9 @@
         }
       },
       "overseerr_defaults": {
-        "title": "Configuración Predeterminada de Overseerr",
-        "description": "Configure el comportamiento predeterminado para las solicitudes de Overseerr",
+        "title": "Configuración de Temporadas Predeterminada de Overseerr",
         "data": {
-          "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define qué temporadas se solicitan cuando no se especifica ninguna"
+          "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define cómo Overseerr maneja las solicitudes de series cuando no se especifican temporadas"
         }
       },
       "reconfigure": {
@@ -71,10 +70,9 @@
         }
       },
       "reconfigure_overseerr_defaults": {
-        "title": "Actualizar Configuración Predeterminada de Overseerr",
-        "description": "Configure el comportamiento predeterminado para las solicitudes de Overseerr",
+        "title": "Configuración de Temporadas Predeterminada de Overseerr",
         "data": {
-          "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define qué temporadas se solicitan cuando no se especifica ninguna"
+          "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define cómo Overseerr maneja las solicitudes de series cuando no se especifican temporadas"
         }
       },
       "reconfigure_radarr_sonarr": {

--- a/custom_components/hassarr/translations/es.json
+++ b/custom_components/hassarr/translations/es.json
@@ -1,0 +1,117 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Elegir Tipo de Integración",
+        "description": "Seleccione qué sistema de solicitud de medios desea integrar",
+        "data": {
+          "integration_type": "Tipo de Integración"
+        }
+      },
+      "radarr_sonarr": {
+        "title": "Conexión Radarr & Sonarr",
+        "description": "Ingrese los detalles de conexión de sus servidores Radarr y Sonarr",
+        "data": {
+          "radarr_url": "URL de Radarr",
+          "radarr_api_key": "Clave API de Radarr",
+          "sonarr_url": "URL de Sonarr",
+          "sonarr_api_key": "Clave API de Sonarr"
+        }
+      },
+      "radarr_sonarr_quality_profiles": {
+        "title": "Perfiles de Calidad",
+        "description": "Seleccione sus perfiles de calidad preferidos para películas y series de TV",
+        "data": {
+          "radarr_quality_profile_id": "Perfil de Calidad de Radarr",
+          "sonarr_quality_profile_id": "Perfil de Calidad de Sonarr"
+        }
+      },
+      "overseerr": {
+        "title": "Conexión de Overseerr",
+        "description": "Ingrese los detalles de conexión de su servidor Overseerr",
+        "data": {
+          "overseerr_url": "URL de Overseerr",
+          "overseerr_api_key": "Clave API de Overseerr"
+        }
+      },
+      "overseerr_user": {
+        "title": "Seleccionar Usuario de Overseerr",
+        "description": "Elija qué usuario de Overseerr se utilizará para las solicitudes",
+        "data": {
+          "overseerr_user_id": "Usuario de Overseerr"
+        }
+      },
+      "overseerr_defaults": {
+        "title": "Configuración Predeterminada de Overseerr",
+        "description": "Configure el comportamiento predeterminado para las solicitudes de Overseerr",
+        "data": {
+          "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define qué temporadas se solicitan cuando no se especifica ninguna"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurar Tipo de Integración",
+        "description": "Seleccione qué sistema de solicitud de medios desea integrar",
+        "data": {
+          "integration_type": "Tipo de Integración" 
+        }
+      },
+      "reconfigure_overseerr": {
+        "title": "Reconfigurar Conexión de Overseerr",
+        "description": "Actualice los detalles de conexión de su Overseerr",
+        "data": {
+          "overseerr_url": "URL de Overseerr",
+          "overseerr_api_key": "Clave API de Overseerr"
+        }
+      },
+      "reconfigure_overseerr_user": {
+        "title": "Actualizar Usuario de Overseerr",
+        "description": "Seleccione qué usuario de Overseerr se utilizará para las solicitudes",
+        "data": {
+          "overseerr_user_id": "Usuario de Overseerr"
+        }
+      },
+      "reconfigure_overseerr_defaults": {
+        "title": "Actualizar Configuración Predeterminada de Overseerr",
+        "description": "Configure el comportamiento predeterminado para las solicitudes de Overseerr",
+        "data": {
+          "default_season_behavior": "Comportamiento Predeterminado de Temporadas - Define qué temporadas se solicitan cuando no se especifica ninguna"
+        }
+      },
+      "reconfigure_radarr_sonarr": {
+        "title": "Actualizar Conexión Radarr & Sonarr",
+        "description": "Actualice los detalles de sus servidores Radarr y Sonarr",
+        "data": {
+          "radarr_url": "URL de Radarr",
+          "radarr_api_key": "Clave API de Radarr",
+          "sonarr_url": "URL de Sonarr",
+          "sonarr_api_key": "Clave API de Sonarr"
+        }
+      },
+      "reconfigure_radarr_sonarr_quality_profiles": {
+        "title": "Actualizar Perfiles de Calidad",
+        "description": "Seleccione sus perfiles de calidad preferidos para películas y series de TV",
+        "data": {
+          "radarr_quality_profile_id": "Perfil de Calidad de Radarr",
+          "sonarr_quality_profile_id": "Perfil de Calidad de Sonarr"
+        }
+      }
+    },
+    "error": {
+      "missing_radarr_info": "Por favor, proporcione tanto la URL como la clave API de Radarr",
+      "missing_sonarr_info": "Por favor, proporcione tanto la URL como la clave API de Sonarr",
+      "missing_overseerr_info": "Por favor, proporcione tanto la URL como la clave API de Overseerr",
+      "cannot_connect": "Error al conectar con el servidor"
+    },
+    "abort": {
+      "already_configured": "La integración ya está configurada"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configurar Opciones de Hassarr",
+        "description": "Actualizar configuración para su sistema de solicitud de medios"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added seasons to overseer tv show request :    
 `seasons = call.data.get("seasons", default_seasons)`

During integration config user can set default season behavior when no season is specified. 
`All or Season 1`

Moved config data schema to translations folder, with english(working) and spanish(untested) 

Clearer titles and descriptions for integration setup
![image](https://github.com/user-attachments/assets/a759648e-7254-4acf-9dd7-2126dab42ca7)
![image](https://github.com/user-attachments/assets/cf68109d-465c-41c0-88f1-79821e83ec27)
![image](https://github.com/user-attachments/assets/badc1f07-a803-49a1-9fba-5418b384d2ba)
![image](https://github.com/user-attachments/assets/b5226050-55bb-4cf2-8ed2-cbde79c68ac7)

